### PR TITLE
Add job analyzer extension

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,6 @@
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.type === 'GET_SELECTION') {
+    const text = window.getSelection().toString();
+    sendResponse({ text });
+  }
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,11 @@
+{
+  "manifest_version": 3,
+  "name": "LinkedIn Job Analyzer",
+  "version": "1.0",
+  "description": "Highlight and capture selected LinkedIn jobs text.",
+  "permissions": ["activeTab", "scripting"],
+  "host_permissions": ["https://www.linkedin.com/*"],
+  "action": {
+    "default_popup": "popup.html"
+  }
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Analyze Selected Jobs</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 10px; width: 200px; }
+    button { width: 100%; padding: 6px; }
+    #output { margin-top: 10px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <button id="analyze-btn">Analyze Selected Jobs</button>
+  <div id="output"></div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('analyze-btn');
+  const output = document.getElementById('output');
+  btn.addEventListener('click', async () => {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!tab) return;
+    chrome.tabs.sendMessage(tab.id, { type: 'GET_SELECTION' }, async (response) => {
+      const text = (response && response.text) ? response.text.trim() : '';
+      if (text) {
+        output.textContent = 'Jobs copied!';
+        try {
+          const res = await fetch('http://localhost:5000/analyze', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ text })
+          });
+          const data = await res.json();
+          if (data && data.message) {
+            output.textContent = data.message;
+          }
+        } catch (e) {
+          console.error('Error sending to backend', e);
+        }
+      } else {
+        output.textContent = 'No text selected.';
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a simple browser extension to capture selected LinkedIn job text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840c0a18ce88323b0f2dfe1fac8804b